### PR TITLE
Upgrade to v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The preserve option is only needed when wanting to keep files/directories on Tal
 
 ```hcl
 module "k8s_cluster" {
-  source = "git::https://github.com/pascalinthecloud/terraform-proxmox-talos-cluster.git?ref=v1.0.0"
+  source = "git::https://github.com/pascalinthecloud/terraform-proxmox-talos-cluster.git?ref=v1.0.2"
 
   cluster = {
     name           = "homelab.cluster"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "k8s_cluster" {
   }
 
   image = {
-    version    = "v1.10.4"
+    version    = "v1.12.0"
     extensions = ["qemu-guest-agent", "iscsi-tools", "util-linux-tools"]
   }
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module "k8s_cluster_override" {
   }
 
   image = {
-    version    = "v1.10.4"
+    version    = "v1.12.0"
     extensions = ["qemu-guest-agent", "iscsi-tools", "util-linux-tools"]
   }
 

--- a/examples/main.example
+++ b/examples/main.example
@@ -56,7 +56,7 @@ module "k8s_cluster_override" {
   }
 
   image = {
-    version    = "v1.10.4"
+    version    = "v1.12.0"
     extensions = ["qemu-guest-agent", "iscsi-tools", "util-linux-tools"]
   }
 

--- a/examples/main.example
+++ b/examples/main.example
@@ -1,5 +1,5 @@
 module "k8s_cluster" {
-  source = "git::https://github.com/pascalinthecloud/terraform-proxmox-talos-cluster.git?ref=v1.0.0"
+  source = "git::https://github.com/pascalinthecloud/terraform-proxmox-talos-cluster.git?ref=v1.0.2"
 
   cluster = {
     name           = "homelab.cluster"

--- a/examples/main.example
+++ b/examples/main.example
@@ -11,7 +11,7 @@ module "k8s_cluster" {
   }
 
   image = {
-    version    = "v1.10.4"
+    version    = "v1.12.0"
     extensions = ["qemu-guest-agent", "iscsi-tools", "util-linux-tools"]
   }
 

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -54,7 +54,7 @@ resource "talos_machine_configuration_apply" "worker" {
   machine_configuration_input = data.talos_machine_configuration.worker.machine_configuration
   node                        = each.value.ip_address
   config_patches = concat([
-    templatefile("${path.module}/templates/install-disk-and-hostname.yaml.tmpl", {
+    templatefile("${path.module}/templates/install-disk.yaml.tmpl", {
       hostname     = each.value.hostname
       install_disk = each.value.install_disk
     })],

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -35,7 +35,7 @@ resource "talos_machine_configuration_apply" "controlplane" {
   machine_configuration_input = data.talos_machine_configuration.controlplane.machine_configuration
   node                        = each.value.ip_address
   config_patches = concat([
-    templatefile("${path.module}/templates/install-disk-and-hostname.yaml.tmpl", {
+    templatefile("${path.module}/templates/install-disk.yaml.tmpl", {
       hostname     = each.value.hostname
       install_disk = each.value.install_disk
     }),

--- a/templates/install-disk-and-hostname.yaml.tmpl
+++ b/templates/install-disk-and-hostname.yaml.tmpl
@@ -1,5 +1,0 @@
-machine:
-  install:
-    disk: ${install_disk}
-  network:
-    hostname: ${hostname}

--- a/templates/install-disk.yaml.tmpl
+++ b/templates/install-disk.yaml.tmpl
@@ -1,0 +1,3 @@
+machine:
+  install:
+    disk: ${install_disk}


### PR DESCRIPTION
Note: with 1.12.0 you can no longer specify the hostname in multiple places, and the v1Alpha definition already includes "auto". The machine name therefore has to be removed from the install-disk-and-hostname template (now just install-disk.yaml.tmpl)

see: https://github.com/siderolabs/talos/issues/10925