### PR TITLE
Fix/bug when upgrading to v1.12.7

### DIFF
--- a/talos_config.tf
+++ b/talos_config.tf
@@ -39,10 +39,18 @@ resource "talos_machine_configuration_apply" "controlplane" {
       hostname     = each.value.hostname
       install_disk = each.value.install_disk
     }),
+    templatefile("${path.module}/templates/network-config.yaml.tmpl", {
+      hostname    = each.key
+      ip_address  = each.value.ip_address
+      subnet      = each.value.subnet
+      gateway     = var.network.gateway
+      dns_servers = var.network.dns_servers
+      interface   = var.cluster.ha_vip_interface
+    }),
     file("${path.module}/templates/cp-scheduling.yaml"),
     ],
     local.ha_vip_enabled ? [templatefile("${path.module}/templates/ha-vip.yaml.tmpl", {
-      vip = local.ha_vip
+      vip       = local.ha_vip
       interface = var.cluster.ha_vip_interface
     })] : [],
     var.cluster.config_patches
@@ -61,6 +69,14 @@ resource "talos_machine_configuration_apply" "worker" {
     templatefile("${path.module}/templates/install-disk.yaml.tmpl", {
       hostname     = each.value.hostname
       install_disk = each.value.install_disk
+    }),
+    templatefile("${path.module}/templates/network-config.yaml.tmpl", {
+      hostname    = each.key
+      ip_address  = each.value.ip_address
+      subnet      = each.value.subnet
+      gateway     = var.network.gateway
+      dns_servers = var.network.dns_servers
+      interface   = var.cluster.ha_vip_interface
     })],
     var.cluster.config_patches
   )

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -40,7 +40,6 @@ resource "talos_machine_configuration_apply" "controlplane" {
       install_disk = each.value.install_disk
     }),
     templatefile("${path.module}/templates/network-config.yaml.tmpl", {
-      hostname    = each.key
       ip_address  = each.value.ip_address
       subnet      = each.value.subnet
       gateway     = var.network.gateway
@@ -71,7 +70,6 @@ resource "talos_machine_configuration_apply" "worker" {
       install_disk = each.value.install_disk
     }),
     templatefile("${path.module}/templates/network-config.yaml.tmpl", {
-      hostname    = each.key
       ip_address  = each.value.ip_address
       subnet      = each.value.subnet
       gateway     = var.network.gateway

--- a/talos_config.tf
+++ b/talos_config.tf
@@ -40,6 +40,7 @@ resource "talos_machine_configuration_apply" "controlplane" {
       install_disk = each.value.install_disk
     }),
     templatefile("${path.module}/templates/network-config.yaml.tmpl", {
+      hostname    = each.key
       ip_address  = each.value.ip_address
       subnet      = each.value.subnet
       gateway     = var.network.gateway
@@ -70,6 +71,7 @@ resource "talos_machine_configuration_apply" "worker" {
       install_disk = each.value.install_disk
     }),
     templatefile("${path.module}/templates/network-config.yaml.tmpl", {
+      hostname    = each.key
       ip_address  = each.value.ip_address
       subnet      = each.value.subnet
       gateway     = var.network.gateway

--- a/talos_image.tf
+++ b/talos_image.tf
@@ -15,6 +15,7 @@ resource "talos_image_factory_schematic" "this" {
         systemExtensions = {
           officialExtensions = data.talos_image_factory_extensions_versions.this.extensions_info[*].name
         }
+        extraKernelArgs = ["net.ifnames=0"]
       }
     }
   )

--- a/templates/network-config.yaml.tmpl
+++ b/templates/network-config.yaml.tmpl
@@ -1,0 +1,19 @@
+---
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: ${hostname}
+---
+machine:
+  network:
+    nameservers:
+%{ for dns in dns_servers ~}
+      - ${dns}
+%{ endfor ~}
+    interfaces:
+      - interface: ${interface}
+        dhcp: false
+        addresses:
+          - ${ip_address}/${subnet}
+        routes:
+          - network: 0.0.0.0/0
+            gateway: ${gateway}

--- a/templates/network-config.yaml.tmpl
+++ b/templates/network-config.yaml.tmpl
@@ -1,8 +1,3 @@
----
-apiVersion: v1alpha1
-kind: HostnameConfig
-hostname: ${hostname}
----
 machine:
   network:
     nameservers:

--- a/templates/network-config.yaml.tmpl
+++ b/templates/network-config.yaml.tmpl
@@ -1,3 +1,9 @@
+---
+apiVersion: v1alpha1
+kind: HostnameConfig
+hostname: ${hostname}
+auto: off
+---
 machine:
   network:
     nameservers:


### PR DESCRIPTION
Recent Talos upgrades changed how hostnames and network configurations are handled. Relying on cloud-init is no longer sufficient; these settings must now be explicitly defined within the machine config.